### PR TITLE
Fixes the node childs when subchildren were present and extends the character customization parser a bit.

### DIFF
--- a/CyberCAT.Core/Classes/NodeRepresentations/CharacterCustomizationAppearances.cs
+++ b/CyberCAT.Core/Classes/NodeRepresentations/CharacterCustomizationAppearances.cs
@@ -14,16 +14,40 @@ namespace CyberCAT.Core.Classes.NodeRepresentations
             public string FirstString { get; set; }
             public string SecondString { get; set; }
             public byte[] TrailingBytes { get; set; }
+
+            public override string ToString()
+            {
+                return $"{FirstString} / {SecondString}";
+            }
         }
+
+        public class ValueEntry
+        {
+            public string FirstString { get; set; }
+            public string SecondString { get; set; }
+            public byte[] TrailingBytes { get; set; }
+
+            public override string ToString()
+            {
+                return $"{FirstString} / {SecondString}";
+            }
+        }
+
         public byte[] UnknownFirstBytes;
+
         /// <summary>
         /// Bytes that are not yet parsed into representation
         /// </summary>
         public byte[] TrailingBytes { get; set; }
         public List<HashValueEntry> ThirdPerson { get; set; }
+        public List<ValueEntry> AdditionalThirdPerson { get; set; }
+        public List<HashValueEntry> FirstPerson { get; set; }
+
         public CharacterCustomizationAppearances()
         {
             ThirdPerson = new List<HashValueEntry>();
+            AdditionalThirdPerson = new List<ValueEntry>();
+            FirstPerson = new List<HashValueEntry>();
         }
        
     }

--- a/CyberCAT.Core/Classes/SaveFile.cs
+++ b/CyberCAT.Core/Classes/SaveFile.cs
@@ -76,7 +76,7 @@ namespace CyberCAT.Core.Classes
                     {
                         if (!node.IsChild)
                         {
-                            FindChildren(_nodes, node);
+                            FindChildren(_nodes, node, _nodes.Count);
                         }
                         if (node.NextId > -1)
                         {
@@ -230,14 +230,14 @@ namespace CyberCAT.Core.Classes
                 _nodes[i].Offset = previousNode.Offset + previousNode.TrueSize;
             }
         }
-        private void FindChildren(List<NodeEntry> nodes, NodeEntry node)
+        private void FindChildren(List<NodeEntry> nodes, NodeEntry node, int maxNextId)
         {
             if (node.ChildId > -1)
             {
                 var nextId = node.NextId;
                 if (nextId == -1)
                 {
-                    nextId = nodes.Count;
+                    nextId = maxNextId;
                 }
                 for (int i = node.ChildId; i < nextId; i++)
                 {
@@ -248,7 +248,7 @@ namespace CyberCAT.Core.Classes
                     }
                     if (possibleChild.ChildId > -1)//SubChild
                     {
-                        FindChildren(nodes, possibleChild);
+                        FindChildren(nodes, possibleChild, nextId);
                         node.AddChild(possibleChild);
                     }
                     else

--- a/CyberCAT.Core/Constants.cs
+++ b/CyberCAT.Core/Constants.cs
@@ -41,6 +41,7 @@ namespace CyberCAT.Core
         public static class Parsing
         {
             public const string TPP_SECTION_NAME = "TPP";
+            public const string FPP_SECTION_NAME = "FPP";
         }
         public static class NodeNames
         {

--- a/CyberCAT.Forms/Classes/CharacterCustomizationAppearancesDisplay.cs
+++ b/CyberCAT.Forms/Classes/CharacterCustomizationAppearancesDisplay.cs
@@ -16,6 +16,8 @@ namespace CyberCAT.Forms.Classes
         {
             UnknownFirstBytes = source.UnknownFirstBytes;
             ThirdPerson = source.ThirdPerson;
+            AdditionalThirdPerson = source.AdditionalThirdPerson;
+            FirstPerson = source.FirstPerson;
             TrailingBytes = source.TrailingBytes;
         }
     }


### PR DESCRIPTION
I did not re-add everything there was before as there were some assumptions that were apparently not true. I have to investigate a bit more.

I tested this with two savefiles and it seems the last 4 bytes of TPP section are an addtional counter for entries without a hash.

The same seems to be true for the other sections as well, I saw this for, e.g., "character_customization".