### PR TITLE
add workaround for version 1.5

### DIFF
--- a/CyberCAT.Core/Classes/Parsers/GenericUnknownStructParser.cs
+++ b/CyberCAT.Core/Classes/Parsers/GenericUnknownStructParser.cs
@@ -164,7 +164,7 @@ namespace CyberCAT.Core.Classes.Parsers
                         }
                     });
 
-                    if (_doMapping) 
+                    if (_doMapping)
                         SetHandlesValue(result);
                     _handles = null;
 
@@ -379,6 +379,10 @@ namespace CyberCAT.Core.Classes.Parsers
             {
                 reader.BaseStream.Position = startPos + fieldInfos[i].Offset;
 
+                if (fieldInfos[i].Type == "DataBuffer") {
+                    continue;
+                };
+
                 var internalType = GetInternalType(fieldInfos[i].Type);
                 var ret = ReadMappedFieldValue(reader, internalType);
 
@@ -471,7 +475,7 @@ namespace CyberCAT.Core.Classes.Parsers
                     return null;
                 }
             }
-            
+
             var subCls = (GenericUnknownStruct.BaseClassEntry)Activator.CreateInstance(internalType);
             ReadMappedFields(reader, subCls);
             return subCls;
@@ -1241,7 +1245,7 @@ namespace CyberCAT.Core.Classes.Parsers
         }
 
         #endregion
-        
+
         private class FieldInfo
         {
             public string Name { get; set; }


### PR DESCRIPTION
with version 1.5, cyberpunk has a new "fieldInfoType" which is "DataBuffer".
![image](https://user-images.githubusercontent.com/11398393/155020163-cb91b1ef-dad0-4492-968b-b12dd321b03d.png)

this pull request adds a workaround to make cybercat works with cyberpunk 1.5 save.